### PR TITLE
Draw map to terminal by rows, not columns

### DIFF
--- a/conmap.pp
+++ b/conmap.pp
@@ -376,8 +376,8 @@ begin
 	DrawMapBorder( N , E , S , W );
 
 	{ Display all terrain. }
-	for X := 0 to ( MapDisplayWidth - 1 ) do begin
-		for Y := 0 to ( MapDisplayHeight - 1 ) do begin
+	for Y := 0 to ( MapDisplayHeight - 1 ) do begin
+		for X := 0 to ( MapDisplayWidth - 1 ) do begin
 			PlotTerrain( gb , X + OriginX , Y + OriginY );
 		end;
 	end;


### PR DESCRIPTION
Terminals are fundamentally row oriented, not column-oriented. This
saves seek calls and avoids the visual lag as the screen updates.