### PR TITLE
Limit price discount to 40%. With enough shopping skill the player can sell goods for 60% of their normal value.

### DIFF
--- a/services.pp
+++ b/services.pp
@@ -99,7 +99,7 @@ begin
 		{ Every point of shopping skill that the unit has }
 		{ gives a 2% discount to whatever is being purchased. }
 		ShopRk := ( ShopRk - ShopTr ) * 2;
-		if ShopRk > 50 then ShopRk := 50;
+		if ShopRk > 40 then ShopRk := 40;
 
 		Price := ( Price * (100 - ShopRk ) ) div 100;
 	end;


### PR DESCRIPTION
Matches https://github.com/jwvhewitt/gearhead-1/blob/0fecc52396cc78feb62ebbec95120c1683dbafed/arenahq.pp#L258

Before with enough shopping skill you could buy gear for 50% it's value then sell it back for 60%. This netted a 20% ROI for just spamming buy and sell. While a fun exploit for a little, it quickly makes actually playing less rewarding by comparison.

Now with enough shopping skill you can buy and sell gear for 60% it's value.