### PR TITLE
Joystick support

### DIFF
--- a/GameData/messages.txt
+++ b/GameData/messages.txt
@@ -649,4 +649,4 @@ ColorSet_3 <Hair>
 ColorSet_4 <Primary>
 ColorSet_5 <Secondary>
 ColorSet_6 <Details>
-
+CONFIG_Prompt <Press the button on your controller that matches the displayed button. Hold any button to skip or press ESC to exit.>

--- a/colormenu.pp
+++ b/colormenu.pp
@@ -336,7 +336,7 @@ begin
 		ColorMenuRedraw;
 		GHFlip;
 
-		a := RPGKey;
+		a := RPGKey(CONTEXT_MENU);
 
 		if a = #8 then begin
 			a := #27;

--- a/gflooker.pp
+++ b/gflooker.pp
@@ -352,7 +352,7 @@ begin
 		IndicateTile( GB , X , Y );
 {$ENDIF}
 
-		A := RPGKey;
+		A := RPGKey{$IFDEF SDLMODE}(CONTEXT_LOOKER){$ENDIF};
 
 		if A = KeyMap[ KMC_North ].KCode then begin
 			RepositionCursor( 6 );

--- a/gharena.pas
+++ b/gharena.pas
@@ -36,7 +36,7 @@ uses gears,congfx,arenahq,conmenus,randchar,navigate,context,mapedit;
 {$ENDIF}
 
 const
-	Version = '1.310';
+	Version = '1.JOY';
 
 var
 	RPM: RPGMenuPtr;
@@ -89,6 +89,9 @@ begin
 	AddRPGMenuItem( RPM , 'View Design Files' , 7 );
 {$IFDEF SDLMODE}
 	AddRPGMenuItem( RPM , 'View Color Selector' , 8 );
+{$IFDEF JOYSTICK_SUPPORT}
+	if HasJoystick then AddRPGMenuItem( RPM , 'Configure Controller' , 9 );
+{$ENDIF}
 {$ENDIF}
 	AddRPGMenuItem( RPM , 'Quit Game' , -1 );
 
@@ -128,6 +131,9 @@ begin
 {$IFDEF SDLMODE}
 			7:	DesignDirBrowser( @RedrawOpening );
             8:  DoCosplay;
+{$IFDEF JOYSTICK_SUPPORT}
+			9:	ConfigureController(@RedrawOpening);
+{$ENDIF}
 {$ELSE}
 			7:	DesignDirBrowser;
 {$ENDIF}

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,11 @@
+1.JOY   X X 2019
+- Somewhat sketchy controller support can be compiled in with -dJOYSTICK_SUPPORT (a lot of files)
+    - Button bindings can be set during play, actions associated with buttons can be set in the config file.
+- Resolution selector added to Play Options (mostly for fullscreen mode) (sdlgfx.pp, ui4gh.pp)
+- NOKEYBOARD option in config file to use on-screen keyboard instead of typing (sdlgfx.pp, ui4gh.pp)
+- Some string utility functions rewritten to use sets (texutil.pp)
+- Fix issue preventing ADVANCEDCOLORS from being enabled [but not any issues with ADVANCEDCOLORS] (ui4gh.pp)
+
 1.310	February 7 2019
 - All old style walls have been replaced by thin walls (sdlmap.pp)
 - Portraits may be assigned as unisex "por_n_*.png" (sdlinfo.pp)

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,10 @@ Open a terminal in the folder with the source code and type:
 
     fpc -dSDLMODE gharena
 
+For controller support in SDL mode, type:
+
+	fpc -dSDLMODE -dJOYSTICK_SUPPORT gharena
+
 For the ASCII version, just type:
 
     fpc gharena

--- a/sdlinfo.pp
+++ b/sdlinfo.pp
@@ -1172,7 +1172,7 @@ var
 	A: Char;
 begin
 	repeat
-		A := RPGKey;
+		A := RPGKey(CONTEXT_MENU);
         if A = RPK_TimeEvent then begin
             if Redrawer <> Nil then Redrawer();
     		RealInjuryDisplay;

--- a/sdlmenus.pp
+++ b/sdlmenus.pp
@@ -521,7 +521,7 @@ begin
 	{or cancels the menu using the ESC key.}
 	repeat
 		{Read the input from the keyboard.}
-		getit := RPGKey;
+		getit := RPGKey(CONTEXT_MENU);
 
 		{Certain keys need processing- if so, process them.}
 		case getit of

--- a/texutil.pp
+++ b/texutil.pp
@@ -52,6 +52,7 @@ Function QuickPCopy( const msg: String ): PChar;
 Function IsPunctuation( C: Char ): Boolean;
 
 Procedure ReplacePat( var msg: String; const pat_in,s: String );
+Function Replace(constref msg, pat_in, s: String): String;
 Function ReplaceHash( const msg, s: String ): String;
 
 Procedure SanitizeFilename( var S: String );
@@ -242,8 +243,7 @@ end;
 function IsAlpha( C: Char ): Boolean;
 	{ Return TRUE if C is a letter, FALSE otherwise. }
 begin
-	if ( UpCase( C ) >= 'A' ) and ( UpCase( C ) <= 'Z' ) then IsAlpha := True
-	else IsAlpha := False;
+	IsAlpha := UpCase(C) in ['A'..'Z'];
 end;
 
 Function Acronym( phrase: String ): String; {can't const}
@@ -359,10 +359,7 @@ Function IsPunctuation( C: Char ): Boolean;
 	{ forgive me if my definition of punctuation in this function }
 	{ is not the same as my own. }
 begin
-	case C of
-		'.',',',':',';','@','!','/','?','''': IsPunctuation := True;
-		else IsPunctuation := False;
-	end;
+	IsPunctuation := C in ['.',',',':',';','@','!','/','?',''''];
 end;
 
 Procedure ReplacePat( var msg: String; const pat_in,s: String );
@@ -378,6 +375,13 @@ begin
 			msg := Copy( msg , 1 , N - 1 ) + S + Copy( msg , N + Length( pat ) , 255 );
 		end;
 	until N = 0;
+end;
+
+Function Replace(constref msg, pat_in, s: String): String;
+	{ Replace a pattern without altering the original string}
+begin
+	Replace := Copy(msg, 0, Length(msg));
+	ReplacePat(Replace, pat_in, s);
 end;
 
 Function ReplaceHash( const msg,s: String ): String;
@@ -398,14 +402,12 @@ end;
 Procedure SanitizeFilename( var S: String );
 	{ Replace all proscribed characters with an underscore. }
 const
-    ProscribedCharacters = ',?"*~#%&{}:<>+|';
+    ProscribedCharacters = [',', '?', '"', '*', '~', '#', '%', '&', '{', '}', ':', '<', '>', '+', '|', ''''];
 var
 	T: Integer;
 begin
 	for T := 1 to Length( S ) do begin
-        if Pos( S[T] , ProscribedCharacters ) > 0 then begin
-            S[T] := '_';
-        end;
+        if S[T] in ProscribedCharacters then S[T] := '_';
 	end;
 end;
 

--- a/ui4gh.pp
+++ b/ui4gh.pp
@@ -385,22 +385,22 @@ const
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_ApplySkill];),
 		(ConfigName: 'ButtonX';
-		  BCode:3;
+		  BCode:2;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_Search];),
 		(ConfigName: 'ButtonY';
-		  BCode:2;
+		  BCode:3;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_AttackMenu];),
 		(ConfigName: 'ButtonStart';
-		  BCode:9;
+		  BCode:7;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_CharInfo];),
 		(ConfigName: 'ButtonSelect';
-		  BCode:8;
+		  BCode:6;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_QuitGame];),
@@ -415,44 +415,44 @@ const
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_Get];),
 		(ConfigName: 'ButtonOther1';
-		  BCode:-1;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:2;
+		  BType:TYPE_AXIS;
+		  BDir:1;
 		  MappedCmd: @KeyMap[KMC_ViewMemo];),
 		(ConfigName: 'ButtonOther2';
-		  BCode:-1;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:2;
+		  BType:TYPE_AXIS;
+		  BDir:-1;
 		  MappedCmd: @KeyMap[KMC_Telephone];),
 		(ConfigName: 'ButtonOther3';
-		  BCode:-1;
+		  BCode:8;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_Stop];),
 		(ConfigName: 'ButtonOther4';
-		  BCode:-1;
+		  BCode:9;
 		  BType:TYPE_BUTTON;
 		  BDir:0;
 		  MappedCmd: @KeyMap[KMC_Rest];),
 		(ConfigName: 'ButtonUp';
-		  BCode:13;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:0;
+		  BType:TYPE_HAT;
+		  BDir:1;
 		  MappedCmd: NIL;),
 		(ConfigName: 'ButtonDown';
-		  BCode:14;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:0;
+		  BType:TYPE_HAT;
+		  BDir:4;
 		  MappedCmd: NIL;),
 		(ConfigName: 'ButtonLeft';
-		  BCode:15;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:0;
+		  BType:TYPE_HAT;
+		  BDir:8;
 		  MappedCmd: NIL;),
 		(ConfigName: 'ButtonRight';
-		  BCode:16;
-		  BType:TYPE_BUTTON;
-		  BDir:0;
+		  BCode:0;
+		  BType:TYPE_HAT;
+		  BDir:2;
 		  MappedCmd: NIL;));
 	{$ENDIF}
 

--- a/ui4gh.pp
+++ b/ui4gh.pp
@@ -32,6 +32,38 @@ type
 		KCode: Char;
 	end;
 
+	{$IFDEF JOYSTICK_SUPPORT}
+	{$PACKENUM 1}
+	TJoyButton = (BUTTON_A,
+				  BUTTON_B,
+				  BUTTON_X,
+				  BUTTON_Y,
+				  BUTTON_START,
+				  BUTTON_SELECT,
+				  BUTTON_L,
+				  BUTTON_R,
+				  BUTTON_OTHER1,
+				  BUTTON_OTHER2,
+				  BUTTON_OTHER3,
+				  BUTTON_OTHER4,
+				  BUTTON_UP,
+			  	  BUTTON_DOWN,
+				  BUTTON_LEFT,
+				  BUTTON_RIGHT,
+				  BUTTON_NONE);
+	TButtonType = (TYPE_BUTTON, TYPE_HAT, TYPE_AXIS, TYPE_NONE);
+
+	TButtonSet = set of TJoyButton;
+
+	TButtonMapDesc = packed record
+		ConfigName: String[12]; {Name for config file}
+		BCode: ShortInt;		{Code for SDL}
+		BType: TButtonType;		{What event to listen to}
+		BDir: ShortInt;			{Which direction (for hat and axis)}
+		MappedCmd: ^KeyMapDesc; {What action this is bound to (directions work differently)}
+	end;
+	{$ENDIF}
+
 const
 	RPK_UpRight = '9';
 	RPK_Up = '8';
@@ -47,6 +79,10 @@ const
 	RPK_TimeEvent = #$91;
 	RPK_RightButton = #$92;
 	FrameDelay: Integer = 50;
+	{$IFDEF JOYSTICK_SUPPORT}
+	JoyXIndex: SmallInt = 0;
+	JoyYIndex: SmallInt = 1;
+	{$ENDIF}
 {$ELSE}
 	FrameDelay: Integer = 100;
 {$ENDIF}
@@ -94,6 +130,10 @@ const
 	UseTacticsMode: Boolean = False;
 
 	UseAdvancedColoring: Boolean = False;
+
+	ModeIndex: Byte = 0;
+
+	OnScreenKeyboard: Boolean = False;
 
     Accessibility_On: Boolean = False;
 
@@ -332,6 +372,96 @@ const
 	KMC_SwitchTarget = 44;
 	KMC_RunToggle = 45;
 
+	{$IFDEF JOYSTICK_SUPPORT}
+	ButtonMap: array [ord(BUTTON_A)..ord(BUTTON_RIGHT)] of TButtonMapDesc =
+		((ConfigName: 'ButtonA';
+		  BCode:0;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Enter];),
+		(ConfigName: 'ButtonB';
+		  BCode:1;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_ApplySkill];),
+		(ConfigName: 'ButtonX';
+		  BCode:3;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Search];),
+		(ConfigName: 'ButtonY';
+		  BCode:2;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_AttackMenu];),
+		(ConfigName: 'ButtonStart';
+		  BCode:9;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_CharInfo];),
+		(ConfigName: 'ButtonSelect';
+		  BCode:8;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_QuitGame];),
+		(ConfigName: 'ButtonL';
+		  BCode:4;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Talk];),
+		(ConfigName: 'ButtonR';
+		  BCode:5;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Get];),
+		(ConfigName: 'ButtonOther1';
+		  BCode:-1;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_ViewMemo];),
+		(ConfigName: 'ButtonOther2';
+		  BCode:-1;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Telephone];),
+		(ConfigName: 'ButtonOther3';
+		  BCode:-1;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Stop];),
+		(ConfigName: 'ButtonOther4';
+		  BCode:-1;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: @KeyMap[KMC_Rest];),
+		(ConfigName: 'ButtonUp';
+		  BCode:13;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: NIL;),
+		(ConfigName: 'ButtonDown';
+		  BCode:14;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: NIL;),
+		(ConfigName: 'ButtonLeft';
+		  BCode:15;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: NIL;),
+		(ConfigName: 'ButtonRight';
+		  BCode:16;
+		  BType:TYPE_BUTTON;
+		  BDir:0;
+		  MappedCmd: NIL;));
+	{$ENDIF}
+
+{$IFDEF JOYSTICK_SUPPORT}
+Function FindButton(val: Integer) : TJoyButton;
+Function FindButton(val: Integer; kind: TButtonType; dir: ShortInt) : TJoyButton;
+Function FindButtonSet(val: Integer; kind: TButtonType) : TButtonSet;
+{$ENDIF}
+
 implementation
 
 uses dos,ability,gears,texutil;
@@ -343,6 +473,9 @@ uses dos,ability,gears,texutil;
 		F: Text;
 		S,CMD,C: String;
 		T: Integer;
+		{$IFDEF JOYSTICK_SUPPORT}
+		U: Integer;
+		{$ENDIF}
 	begin
 		{See whether or not there's a configuration file.}
 		S := FSearch(Config_File,'.');
@@ -364,8 +497,49 @@ uses dos,ability,gears,texutil;
 							if Length(C) = 1 then begin
 								KeyMap[t].KCode := C[1];
 							end;
+							break;
 						end;
 					end;
+
+					{$IFDEF JOYSTICK_SUPPORT}
+					{loading button mapping from the config}
+					for t := Low(ButtonMap) to High(ButtonMap) do begin
+						if UpCase(ButtonMap[t].ConfigName) = cmd then begin
+							C := ExtractWord(S);
+
+							if Length(C) = 1 then begin
+								case C[1] of
+									'H': ButtonMap[t].BType := TYPE_HAT;
+									'A': ButtonMap[t].BType := TYPE_AXIS;
+								else
+									ButtonMap[t].BType := TYPE_BUTTON;
+								end;
+							end;
+
+							ButtonMap[t].BCode := ExtractValue(S);
+							if ButtonMap[t].BType <> TYPE_BUTTON then ButtonMap[t].BDir := ExtractValue(S);
+							C := UpCase(ExtractWord(S));
+							ButtonMap[t].MappedCmd := NIL;
+
+							if C <> '' then begin
+								for U := Low(KeyMap) to High(KeyMap) do begin
+									if UpCase(KeyMap[U].CmdName) = C then begin
+										ButtonMap[t].MappedCmd := @KeyMap[U];
+										break;
+									end;
+								end;
+							end;
+
+							break;
+						end;
+					end;
+
+					if cmd = 'BUTTONANALOGX' then begin
+						JoyXIndex := ExtractValue(S);
+					end else if cmd = 'BUTTONANALOGY' then begin
+						JoyYIndex := ExtractValue(S);
+					end;
+					{$ENDIF}
 
 					{ Check to see if CMD is the animation speed throttle. }
 					if cmd = 'ANIMSPEED' then begin
@@ -472,8 +646,17 @@ uses dos,ability,gears,texutil;
 					end else if cmd = 'USETACTICSMODE' then begin
 						UseTacticsMode := True;
 
-					end else if cmd = 'AdvancedColors' then begin
+					end else if cmd = 'ADVANCEDCOLORS' then begin
 						UseAdvancedColoring := True;
+
+					end else if cmd = 'MODE' then begin
+						T := ExtractValue( S );
+						if T > 255 then T := 255
+						else if T < 0 then T := 0;
+						ModeIndex := T;
+
+					end else if cmd = 'NOKEYBOARD' then begin
+						OnScreenKeyboard := True;
 
                     end else if cmd = 'ACCESSIBILITY_ON' then begin
                         Accessibility_On := True;
@@ -497,6 +680,9 @@ uses dos,ability,gears,texutil;
     var
 	    F: Text;
 	    T: Integer;
+		{$IFDEF JOYSTICK_SUPPORT}
+		S: String;
+		{$ENDIF}
 	    Procedure AddBoolean( const OpTag: String; IsOn: Boolean );
 		    { Add one of the boolean options to the file. }
 	    begin
@@ -508,7 +694,7 @@ uses dos,ability,gears,texutil;
 	    end;
     begin
 	    { If we've found a configuration file, }
-	    { open it up and start reading. }
+	    { open it up and start writing. }
 	    Assign( F , Config_File );
 	    Rewrite( F );
 
@@ -521,6 +707,22 @@ uses dos,ability,gears,texutil;
 	    for t := 1 to NumMappedKeys do begin
 		    WriteLn( F, KeyMap[t].CmdName + ' ' + KeyMap[t].KCode );
 	    end;
+
+		{$IFDEF JOYSTICK_SUPPORT}
+		for t := Low(ButtonMap) to High(ButtonMap) do begin
+			S := ButtonMap[t].ConfigName + ' ';
+			case ButtonMap[t].BType of
+				TYPE_BUTTON: 	S += 'B ' + BStr(ButtonMap[t].BCode);
+				TYPE_HAT: 		S += 'H ' + BStr(ButtonMap[t].BCode) + ' ' + BStr(ButtonMap[t].BDir);
+				TYPE_AXIS: 		S += 'A ' + BStr(ButtonMap[t].BCode) + ' ' + BStr(ButtonMap[t].BDir);
+			end;
+			if ButtonMap[t].MappedCmd <> NIL then S += ' ' + ButtonMap[t].MappedCmd^.CmdName;
+			WriteLn(F, S);
+		end;
+
+		writeln(F, 'ButtonAnalogX ' + BStr(JoyXIndex));
+		writeln(F, 'ButtonAnalogY ' + BStr(JoyYIndex));
+		{$ENDIF}
 
 	    writeln( F, 'ANIMSPEED ' + BStr( FrameDelay ) );
 
@@ -551,14 +753,54 @@ uses dos,ability,gears,texutil;
 
 	    AddBoolean( 'FULLSCREEN' , DoFullScreen );
 	    AddBoolean( 'NOMOUSE' , not Mouse_Active );
+		AddBoolean( 'NOKEYBOARD', OnScreenKeyboard );
 	    AddBoolean( 'NOPILLAGE' , not Pillage_On );
 	    AddBoolean( 'USETACTICSMODE' , UseTacticsMode );
 
 	    AddBoolean( 'ADVANCEDCOLORS' ,  UseAdvancedColoring );
+		writeln( F , 'MODE ' + BStr( ModeIndex ) );
 	    AddBoolean( 'ACCESSIBILITY_ON' ,  Accessibility_On );
 
 	    Close(F);
     end;
+
+	{$IFDEF JOYSTICK_SUPPORT}
+	Function FindButton(val: Integer) : TJoyButton;
+		{ Returns the mapped button for the entered button index }
+	var
+		i: TJoyButton;
+	begin
+		for i := BUTTON_A to BUTTON_RIGHT do begin
+			if (ButtonMap[ord(i)].BType = TYPE_BUTTON) and (ButtonMap[ord(i)].BCode = val) then Exit(i);
+		end;
+		
+		FindButton := BUTTON_NONE;
+	end;
+
+	Function FindButton(val: Integer; kind: TButtonType; dir: ShortInt) : TJoyButton;
+		{FindButton, but for hats and axis}
+	var
+		i: TJoyButton;
+	begin
+		for i := BUTTON_A to BUTTON_RIGHT do begin
+			if (ButtonMap[ord(i)].BType = kind) and (ButtonMap[ord(i)].BDir = dir) and (ButtonMap[ord(i)].BCode = val) then Exit(i);
+		end;
+		
+		FindButton := BUTTON_NONE;
+	end;
+
+	Function FindButtonSet(val: Integer; kind: TButtonType) : TButtonSet;
+		{Return a set of all buttons associated with an index}
+	var
+		i: TJoyButton;
+	begin
+		FindButtonSet := [];
+
+		for i := BUTTON_A to BUTTON_RIGHT do begin
+			if (ButtonMap[ord(i)].BType = kind) and (ButtonMap[ord(i)].BCode = val) then Include(FindButtonSet, i);
+		end;
+	end;
+	{$ENDIF}
 
 
 initialization


### PR DESCRIPTION
Patches in support for joystick controls via SDL. It's a little wonky due to the way GearHead uses input and due to me not wanting to do a significant rewrite just for a feature I'm not sure anyone else would want.

There's a configuration UI that can be accessed in-game to map your controller buttons, and it supports mapping hats and axes. The hard-coded defaults should hopefully work for an Xbox 360 controller. The actions mapped to each button can be changed in the config file. The main analog stick axes can be (only) set in the config file, and I've aped the control scheme used by games like Tangledeep, where you select a square with the analog stick and press A to confirm the movement. All buttons repeat if held, also.

There's also a minimal on-screen keyboard that can be enabled via the config file, so that it should be at least technically possible to play the game without needing anything other than a controller.

Finally a simple resolution menu is buried in the play options, mostly so that it's possible to do fullscreen at a resolution other than 800x600.

There are a couple other little tweaks here and there because I couldn't help myself, but nothing that should impact anything.