### PR TITLE
Let knowledge-boosting cyberware contribute towards skill slots.

### DIFF
--- a/ghchars.pp
+++ b/ghchars.pp
@@ -4,6 +4,7 @@ unit ghchars;
 {
 	GearHead: Arena, a roguelike mecha CRPG
 	Copyright (C) 2005 Joseph Hewitt
+	Copyright (C) 2005 Maxime Devos
 
 	This library is free software; you can redistribute it and/or modify it
 	under the terms of the GNU Lesser General Public License as published by
@@ -438,7 +439,7 @@ Procedure ApplyTalent( PC: GearPtr; T: Integer );
 
 implementation
 
-uses texutil;
+uses gearutil, texutil;
 
 Procedure InitChar(Part: GearPtr);
 	{PART is a newly created Character record.}
@@ -731,7 +732,13 @@ Function NumberOfSkillSlots( PC: GearPtr ): Integer;
 var
 	N: Integer;
 begin
-	N := ( ( PC^.STat[ STAT_Knowledge ] * 6 ) div  5 + 5 );
+	{ A PC might want to upgrade their brain with cyberware to help }
+	{ with learning skills, so use CStat instead of STat to take }
+	{ cyberware in account. This also results in status conditions }
+	{ being taken in account, which seems fitting -- having a bad }
+	{ mood wouldn't help with learning. }
+
+	N := ( ( CStat ( PC, STAT_KNOWLEDGE ) * 6) div 5 + 5 );
 	if NAttValue( PC^.NA , NAG_Talent , NAS_Savant ) <> 0 then N := N + 5;
 	NumberOfSkillSlots := N;
 end;

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,6 @@
+?.???   February 5 2023
+- Knowledge adjustments from cyberware and mood contribute towards skill slots (ghchars.pp)
+
 1.310	February 7 2019
 - All old style walls have been replaced by thin walls (sdlmap.pp)
 - Portraits may be assigned as unisex "por_n_*.png" (sdlinfo.pp)

--- a/license.txt
+++ b/license.txt
@@ -1,10 +1,14 @@
-The GearHead Universe is Copyright 2005 by Joseph Hewitt.
+The GearHead Universe is mostly Copyright 2005 by Joseph Hewitt,
+with some small contributions by other people under copyrigh by the
+other people.
+
 GearHead: Arena is a computer game set in the GearHead Universe,
 and is distributed under the terms of the GNU Lesser General
 Public License.
 
 GearHead: Arena, a roguelike mecha CRPG
 Copyright (C) 2005 Joseph Hewitt
+Copyright (C) 2023 Maxime Devos
 
 pyrrho12@yahoo.ca
 http://www.gearheadrpg.com


### PR DESCRIPTION
According to doc/man_chara.txt, the number of skill slots is determined by the Knowledge stat:

> Your character will pay more for training if too many skills are known.
> The total number of skills your character can have without penalty is
> determined by the Knowledge stat.

All the skill slots of my PC were full, so I installed some brain cyberware to improve the Knowledge stat, to increase the number of skill slots, but without effect!

Perhaps this is intentional, but I think this is a bug, so here's a PR.
(The same change may be needed in gearhead-2 as well.)